### PR TITLE
Change the order of installing tools with Docker first

### DIFF
--- a/setup/vm-install-script/install-script.sh
+++ b/setup/vm-install-script/install-script.sh
@@ -17,7 +17,7 @@ EOF
 
 KUBE_VERSION=1.20.0
 apt-get update
-apt-get install -y kubelet=${KUBE_VERSION}-00 vim build-essential jq python3-pip docker.io kubectl=${KUBE_VERSION}-00 kubernetes-cni=0.8.7-00 kubeadm=${KUBE_VERSION}-00
+apt-get install -y docker.io vim build-essential jq python3-pip kubelet=${KUBE_VERSION}-00 kubectl=${KUBE_VERSION}-00 kubernetes-cni=0.8.7-00 kubeadm=${KUBE_VERSION}-00
 pip3 install jc
 
 ### UUID of VM 


### PR DESCRIPTION
hello, I had an error while installing Kubeadm and the error message was because there was no container engine, then I tried to install docker at the beginning. Also, I changed the code so that docker is installed at the beginning